### PR TITLE
Create _mech_context before delete to avoid race

### DIFF
--- a/neutron/db/db_base_plugin_v2.py
+++ b/neutron/db/db_base_plugin_v2.py
@@ -1048,6 +1048,8 @@ class NeutronDbPluginV2(db_base_plugin_common.DbBasePluginCommon,
         self._delete_subnet(context, subnet)
 
     def _delete_subnet(self, context, subnet):
+        registry.notify(resources.SUBNET, events.BEFORE_DELETE,
+                        self, context=context, subnet_id=subnet.id)
         with lib_db_api.exc_to_retry(sql_exc.IntegrityError), \
                 db_api.context_manager.writer.using(context):
             registry.notify(resources.SUBNET, events.PRECOMMIT_DELETE,

--- a/releasenotes/notes/fix-net-delete-race-f2fa5bac3ab35a5b.yaml
+++ b/releasenotes/notes/fix-net-delete-race-f2fa5bac3ab35a5b.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixes an issue where deletion of a provider network could result in ML2
+    mechanism drivers not being passed information about the network's provider
+    fields. The consequences of this depend on the mechanism driver in use, but
+    could result in the event being ignored, leading to an incorrectly
+    configured network. See `bug 1841967
+    <https://bugs.launchpad.net/neutron/+bug/1841967>`__ for details.


### PR DESCRIPTION
When a network is deleted, precommit handlers are notified prior to the
deletion of the network from the database. One handler exists in the ML2
plugin - _network_delete_precommit_handler. This handler queries the
database for the current state of the network and uses it to create a
NetworkContext which it saves under context._mech_context. When the
postcommit handler _network_delete_after_delete_handler is triggered
later, it passess the saved context._mech_context to mechanism drivers.

A problem can occur with provider networks since the segments service
also registers a precommit handler - _delete_segments_for_network. Both
precommit handlers use the default priority, so the order in which they
are called is random, and determined by dict ordering. If the segment
precommit handler executes first, it will delete the segments associated
with the network. When the ML2 plugin precommit handler runs it then
sees no segments for the network and sets the provider attributes of the
network in the NetworkContext to None.

A mechanism driver that is passed a NetworkContext without provider
attributes in its delete_network_postcommit method will not have the
information to perform the necessary actions.  In the case of the
networking-generic-switch mechanism driver where this was observed, this
resulted in the driver ignoring the event, because the network did not
look like a VLAN.

This change adds an additional callback registration to the ML2 plugin
for BEFORE_DELETE, which is used to query the network and store the
NetworkContext before the segments service has a chance to delete
segments.

A similar change has been made for subnets, both to keep the pattern
consistent and avoid any similar issues.

Finally, context._mech_context has been renamed to
context._network_mech_context or context._subnet_mech_context to avoid
overwriting the network context with a subnet context when a network
deletion triggers a subnet deletion.

Closes-Bug: #1841967