### PR TITLE
Hardcode metadata ipv6 to be off

### DIFF
--- a/neutron/agent/dhcp/agent.py
+++ b/neutron/agent/dhcp/agent.py
@@ -746,7 +746,7 @@ class DhcpAgent(manager.Manager):
                     self._metadata_routers[network.id] = (
                         router_ports[0].device_id)
 
-        if netutils.is_ipv6_enabled():
+        if netutils.is_ipv6_enabled() and False:
             try:
                 dhcp_ifaces = [
                     self.call_driver(


### PR DESCRIPTION
We hit issues with dhcp ha where the same metadata ipv6 address attempts to be present on two hosts.
We simply turn that off for now.