### PR TITLE
Correct logic error when associating FIP with OVN LB

### DIFF
--- a/neutron/plugins/ml2/drivers/ovn/mech_driver/ovsdb/ovn_client.py
+++ b/neutron/plugins/ml2/drivers/ovn/mech_driver/ovsdb/ovn_client.py
@@ -974,7 +974,7 @@ class OVNClient(object):
                 if lb in item.load_balancer]
 
             if not ls_linked:
-                return
+                continue
 
             # Find out IP addresses and subnets of configured members.
             members_to_verify = []

--- a/releasenotes/notes/fix-issue-with-ovn-loadbalancer-fip-4e4bda00cf019f71.yaml
+++ b/releasenotes/notes/fix-issue-with-ovn-loadbalancer-fip-4e4bda00cf019f71.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes an issue when associating FIPs to OVN loadbalancers. See `LP#2068644
+    <https://bugs.launchpad.net/neutron/+bug/2068644>`__ for more details.


### PR DESCRIPTION
Fixes a logic error which meant that we didn't iterate over all logical switches when associating a FIP to an OVN loadbalancer. The symptom was that the FIP would show in neutron, but would not exist in OVN.

Closes-Bug: #2068644
Change-Id: I6d1979dfb4d6f455ca419e64248087047fbf73d7
Co-Authored-By: Brian Haley <haleyb.dev@gmail.com>
(cherry picked from commit befb7ec6f5fe8f74b41a97da64b4049d591ffa02)