### PR TITLE
Clean up state VRRP PID file

### DIFF
--- a/neutron/agent/linux/keepalived.py
+++ b/neutron/agent/linux/keepalived.py
@@ -27,6 +27,7 @@ from oslo_utils import fileutils
 
 from neutron._i18n import _
 from neutron.agent.linux import external_process
+from neutron.agent.linux import utils as linux_utils
 from neutron.cmd import runtime_checks as checks
 from neutron.common import utils
 
@@ -504,8 +505,12 @@ class KeepalivedManager(object):
             # will be orphan and prevent keepalived process to be spawned.
             # A check here will let the l3-agent to kill the orphan process
             # and spawn keepalived successfully.
+            # Also removes stale pid file
             if vrrp_pm.active:
-                vrrp_pm.disable()
+                vrrp_pm.disable(delete_pid_file=False)
+
+            linux_utils.delete_if_exists(self.get_vrrp_pid_file_name(pid_file),
+                                         run_as_root=vrrp_pm.run_as_root)
 
             cmd = ['keepalived', '-P',
                    '-f', config_path,


### PR DESCRIPTION
Change Id62bf18067d0b144c3e8825c7603cc1e51dca052 removes explicit PID files clean up for keepalived and brings regression as there is no 'process enable' for VRRP.

Always delete stale PID file if exists

Related-Bug: 1561046
Change-Id: I95a004a3acbe6a9160a19053a37fc0dd2b1875a5
(cherry picked from commit d3a8c9ca0f668cfefc271d7db01dbf0badbbecec)
(cherry picked from commit 0b28687f0c07d3a462ee75f6fdd6e2d2ed9d078b)