### PR TITLE
2025.1 ovn chassis

### DIFF
--- a/neutron/common/ovn/utils.py
+++ b/neutron/common/ovn/utils.py
@@ -901,6 +901,16 @@ def get_chassis_without_azs(chassis_list):
             get_chassis_availability_zones(ch)}
 
 
+def get_chassis_priority(chassis_list):
+    """Given a chassis list, returns a dictionary with chassis name and prio
+
+    The chassis list is ordered according to the priority: the first one is the
+    highest priority chassis, the last one is the least priority chassis.
+    """
+    return {chassis: prio + 1 for prio, chassis
+            in enumerate(reversed(chassis_list))}
+
+
 def parse_ovn_lb_port_forwarding(ovn_rtr_lb_pfs):
     """Return a dictionary compatible with port forwarding from OVN lb."""
     result = {}

--- a/neutron/plugins/ml2/drivers/ovn/mech_driver/ovsdb/commands.py
+++ b/neutron/plugins/ml2/drivers/ovn/mech_driver/ovsdb/commands.py
@@ -99,6 +99,31 @@ def _add_gateway_chassis(api, txn, lrp_name, val):
         uuid_list.append(gwc.uuid)
     return 'gateway_chassis', uuid_list
 
+def _add_ha_chassis_group(api, txn, lrouter_name, chassis_priority, may_exist=True):
+    hc_uuid_list = []
+    for chassis in chassis_priority:
+        prio = chassis_priority[chassis]
+        try:
+            hc = idlutils.row_by_value(
+                api.idl, 'HA_Chassis', 'chassis_name', chassis)
+        except idlutils.RowNotFound:
+            hc = txn.insert(api._tables.get('HA_Chassis'))
+        hc.chassis_name = chassis
+        hc.priority = prio
+        LOG.info(
+                "Schedule Router %(lr)s on gateway %(gtw)s with priority %(prio)s",
+                {"lr": lrouter_name, "gtw": chassis, "prio": prio})
+        hc_uuid_list.append(hc.uuid)
+    hcg_name = lrouter_name
+    try:
+        hcg = idlutils.row_by_value(
+                api.idl, 'HA_Chassis_Group', 'name', hcg_name)
+    except idlutils.RowNotFound:
+        hcg = txn.insert(api._tables.get('HA_Chassis_Group'))
+    hcg.name = hcg_name
+    hcg.ha_chassis = hc_uuid_list
+    return hcg.uuid
+
 
 class CheckLivenessCommand(command.BaseCommand):
     def run_idl(self, txn):
@@ -388,9 +413,12 @@ class ScheduleUnhostedGatewaysCommand(command.BaseCommand):
                 # the top.
                 index = chassis.index(primary)
                 chassis[0], chassis[index] = chassis[index], chassis[0]
-        setattr(
-            lrouter_port,
-            *_add_gateway_chassis(self.api, txn, self.g_name, chassis))
+        chassis_priority = utils.get_chassis_priority(chassis)
+        lrouter_name = lrouter_port.external_ids[
+            ovn_const.OVN_ROUTER_NAME_EXT_ID_KEY]
+        hcg = _add_ha_chassis_group(self.api, txn, lrouter_name,
+                                    chassis_priority, may_exist=True)
+        setattr(lrouter_port, 'ha_chassis_group', ovsdbapp_utils.get_uuid(hcg))
 
 
 class ScheduleNewGatewayCommand(command.BaseCommand):
@@ -415,8 +443,13 @@ class ScheduleNewGatewayCommand(command.BaseCommand):
             self.api, self.sb_api, self.g_name, candidates=candidates,
             target_lrouter=lrouter)
         if chassis:
-            setattr(lrouter_port,
-                    *_add_gateway_chassis(self.api, txn, self.g_name, chassis))
+            chassis_priority = utils.get_chassis_priority(chassis)
+            lrouter_name = lrouter_port.external_ids[
+                ovn_const.OVN_ROUTER_NAME_EXT_ID_KEY]
+            hcg = _add_ha_chassis_group(self.api, txn, lrouter_name,
+                                        chassis_priority, may_exist=True)
+            setattr(lrouter_port, 'ha_chassis_group',
+                    ovsdbapp_utils.get_uuid(hcg))
 
 
 class LrDelCommand(ovn_nb_commands.LrDelCommand):
@@ -1008,14 +1041,16 @@ class DeleteLRouterExtGwCommand(command.BaseCommand):
         # Remove the router pinning to a chassis (if any).
         lrouter.delkey('options', 'chassis')
 
-        # Remove the HA_Chassis_Group of the router (if any).
+        for gw_port in self.api.get_lrouter_gw_ports(lrouter.name):
+            gw_port.ha_chassis_group = []
+            lrouter.delvalue('ports', gw_port)
+
+        # Remove the HA_Chassis_Group of the router (if any), after
+        # removing it from the gateway Logical_Router_Ports.
         hcg = self.api.lookup('HA_Chassis_Group',
                               lrouter.name, default=None)
         if hcg:
             hcg.delete()
-
-        for gw_port in self.api.get_lrouter_gw_ports(lrouter.name):
-            lrouter.delvalue('ports', gw_port)
 
 
 class SetLSwitchPortToVirtualTypeCommand(command.BaseCommand):

--- a/neutron/plugins/ml2/drivers/ovn/mech_driver/ovsdb/maintenance.py
+++ b/neutron/plugins/ml2/drivers/ovn/mech_driver/ovsdb/maintenance.py
@@ -1160,6 +1160,41 @@ class DBInconsistenciesPeriodics(SchemaAwarePeriodicsBase):
 
         raise periodics.NeverAgain()
 
+    # TODO(ralonsoh): Remove this method in F+3 cycle (2nd next SLURP release)
+    @has_lock_periodic(
+        periodic_run_limit=ovn_const.MAINTENANCE_TASK_RETRY_LIMIT,
+        spacing=ovn_const.MAINTENANCE_ONE_RUN_TASK_SPACING,
+        run_immediately=True)
+    def migrate_lrp_gateway_chassis_to_ha_chassis_group(self):
+        """Migrate the LRP Gateway_Chassis to HA_Chassis_Group"""
+        with self._nb_idl.transaction(check_error=True) as txn:
+            for lrp in self._nb_idl.db_list_rows(
+                    'Logical_Router_Port').execute(check_error=True):
+                if not lrp.gateway_chassis:
+                    continue
+
+                chassis_prio = {}
+                for gc in lrp.gateway_chassis:
+                    chassis_prio[gc.chassis_name] = gc.priority
+                r_name = lrp.external_ids.get(
+                    ovn_const.OVN_ROUTER_NAME_EXT_ID_KEY)
+                if not r_name:
+                    LOG.warning(f'Logical_Router_Port {lrp.name} does not '
+                                'have the router name in external_ids.')
+                    continue
+
+                # Add the new HA_Chassis_Group and assign to the LRP.
+                hcg_cmd = txn.add(self._nb_idl.ha_chassis_group_with_hc_add(
+                    r_name, chassis_prio, may_exist=True))
+                txn.add(self._nb_idl.db_set(
+                    'Logical_Router_Port', lrp.uuid,
+                    ('ha_chassis_group', hcg_cmd)))
+                # Unset the Gateway_Chassis in the LRP.
+                txn.add(self._nb_idl.db_clear(
+                    'Logical_Router_Port', lrp.uuid, 'gateway_chassis'))
+
+        raise periodics.NeverAgain()
+
 
 class HashRingHealthCheckPeriodics:
 

--- a/neutron/tests/functional/plugins/ml2/drivers/ovn/mech_driver/ovsdb/test_maintenance.py
+++ b/neutron/tests/functional/plugins/ml2/drivers/ovn/mech_driver/ovsdb/test_maintenance.py
@@ -27,6 +27,7 @@ from neutron_lib.callbacks import registry
 from neutron_lib import constants as n_const
 from neutron_lib import context as n_context
 from neutron_lib.exceptions import l3 as lib_l3_exc
+from neutron_lib.utils import net as net_utils
 from oslo_utils import uuidutils
 from sqlalchemy.dialects.mysql import dialect as mysql_dialect
 
@@ -1479,6 +1480,44 @@ class TestMaintenance(_TestMaintenanceHelper):
                 self.assertEqual(fip_prio, qos_rule.priority)
             else:
                 self.assertEqual(def_prio, qos_rule.priority)
+
+    def test_migrate_lrp_gateway_chassis_to_ha_chassis_group(self):
+        mac = next(net_utils.random_mac_generator(['ca', 'fe', 'ca', 'fe']))
+        networks = ['192.0.2.0/24']
+        lr_name = uuidutils.generate_uuid()
+        lrp_name = uuidutils.generate_uuid()
+        gateway_chassis = ['gw_ch1', 'gw_ch2', 'gw_ch3']
+
+        self.nb_api.lr_add(lr_name).execute(check_error=True)
+        ext_ids = {ovn_const.OVN_ROUTER_NAME_EXT_ID_KEY: lr_name}
+        self.nb_api.add_lrouter_port(
+            lrp_name, lr_name, mac=mac,
+            networks=networks, gateway_chassis=gateway_chassis,
+            external_ids=ext_ids).execute(check_error=True)
+
+        hcg = self.nb_api.lookup('HA_Chassis_Group', lr_name, default=None)
+        self.assertIsNone(hcg)
+        lr = self.nb_api.lookup('Logical_Router_Port', lrp_name)
+        chassis_prio = {}
+        for gc in lr.gateway_chassis:
+            chassis_prio[gc.chassis_name] = gc.priority
+
+        self.assertRaises(
+            periodics.NeverAgain,
+            self.maint.migrate_lrp_gateway_chassis_to_ha_chassis_group)
+
+        hcg = self.nb_api.lookup('HA_Chassis_Group', lr_name, default=None)
+        self.assertEqual(len(chassis_prio), len(hcg.ha_chassis))
+        for ha_chassis in hcg.ha_chassis:
+            try:
+                # The priority and the chassis_name of the former
+                # Gateway_Chassis registers must match the new HA_Chassis ones.
+                self.assertEqual(ha_chassis.priority,
+                                 chassis_prio.pop(ha_chassis.chassis_name))
+            except KeyError:
+                self.fail(f'HA_Chassis with chassis name '
+                          f'{ha_chassis.chassis_name} not present in the '
+                          f'chassis list')
 
 
 class TestLogMaintenance(_TestMaintenanceHelper,


### PR DESCRIPTION
Backport unmerged Neutron patches planned for 2026.1
These can't be merged, because ovn-octavia-provider relies on Gateway_Chassis in 2025.1 GA

A fix has been backported ovn-octavia-provider (https://review.opendev.org/c/openstack/ovn-octavia-provider/+/948314), and is already in our downstream images.

Leaving with WIP in the name to bring attention when cherry picking to 2026.1 which is not required - because the upstream plan is to merge these patches in 2026.1.