### PR TITLE
Backport bugfix/2139581 (Add check for null when updating router state)

### DIFF
--- a/neutron/db/l3_hamode_db.py
+++ b/neutron/db/l3_hamode_db.py
@@ -615,7 +615,8 @@ class L3_HA_NAT_db_mixin(l3_dvr_db.L3_NAT_with_dvr_db_mixin,
             # List agents where router is active and agent is dead
             # and agents where router is standby and agent is dead
             for binding in bindings:
-                if not (binding.agent.is_active and
+                if not (binding.agent and
+                        binding.agent.is_active and
                         binding.agent.admin_state_up):
                     if binding.state == constants.HA_ROUTER_STATE_ACTIVE:
                         router_active_agents_dead.append(binding.agent)


### PR DESCRIPTION
Fixes issue where periodic tasks can fail if binding.agent returns a NoneType

Closes-Bug: #2139581
Change-Id: I5c526c8722c228c370e959ceb37e5ffb860fa407